### PR TITLE
style(css): add Tailwind CSS with custom theme variables

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,27 +1,15 @@
 @import "tailwindcss";
 
-/* globals.css */
-
 @theme {
   --color-background: #0e0c1a;
   --color-foreground: #f5f5f7;
 
-  --color-primary: #7b3fe4; /* Main violet/purple */
-  --color-primary-dark: #5522b5; /* For hover or deep accents */
+  --color-primary: #cf0f47;
+  --color-secondary: #ff0b55;
 
-  --color-secondary: #3e2f85; /* Soft background element tone */
-  --color-accent: #8b5cf6; /* Indigo-light for highlights */
-
-  --color-border: #29223b;
-  --color-card: #1a162a;
-
-  --color-muted: #a1a1aa;
+  --color-background: #000000;
+  --color-accent: #ffdede;
 
   --font-sans: "Inter", system-ui, sans-serif;
   --font-mono: "JetBrains Mono", monospace;
-}
-:root.dark,
-.dark :root {
-  --color-background: #0a0815;
-  --color-foreground: #f0f0f4;
 }


### PR DESCRIPTION
Add Tailwind CSS import and custom theme variables to globals.css for the portfolio landing page. Define primary (#cf0f47), secondary (#ff0b55), accent (#ffdede), and neutral colors, plus Inter and JetBrains Mono fonts.